### PR TITLE
addy new --format custom --local-part mylocalpart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-new: added local_parts for custom mail aliasing.
+new: added local_parts for custom mail aliasing and removed all text output from `addy new` command except the json (for further processing with jq).
 
 # pyaddy
 A Python CLI to interact with addy.io

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+new: added local_parts for custom mail aliasing.
+
 # pyaddy
 A Python CLI to interact with addy.io
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.poetry]
 name = "pyaddy"
-version = "0.5.5"
+version = "0.5.6"
 description = "A Python package/cli to interact with addy.io"
-authors = ["Maurice Saldivar <mo.py.solutions@gmail.com>"]
+authors = ["Maurice Saldivar <mo.py.solutions@gmail.com>", "clappedscant906"]
 license = "GNU AFFERO GENERAL PUBLIC LICENSE"
 readme = "README.md"
-homepage = "https://github.com/msaldivar/pyaddy"
+homepage = "https://github.com/clappedscant906/pyaddy"
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/src/pyaddy/commands/aliases_cmd.py
+++ b/src/pyaddy/commands/aliases_cmd.py
@@ -71,7 +71,7 @@ def get_specific_alias(id):
 )
 @click.option(
     "--format",
-    help="chosen format for the alias: random_characters, uuid, or random_words",
+    help="chosen format for the alias: random_characters, uuid, random_words or custom",
     type=str,
 )
 @click.option(
@@ -79,13 +79,18 @@ def get_specific_alias(id):
     help="recipient id to add. Default recipient will be used if non is provided",
     type=str,
 )
-def create_new_alias(domain, description, format, recipient_id):
+@click.option(
+    "--local-part",
+    help="local part of the mail (used only if --format=custom",
+    type=str,
+)
+def create_new_alias(domain, description, format, recipient_id, local_part):
     """Create a new alias
 
     Usage:\n
     addy alias new
 
-    addy alias new --domain addymail.com --description "addy created" --format random_words
+    addy alias new --domain addymail.com --description "addy created" --format random_words --local-part mycustomalias
     """
 
     payload = {
@@ -93,10 +98,12 @@ def create_new_alias(domain, description, format, recipient_id):
         "description": description,
         "format": format,
         "recipient_id": recipient_id,
+        "local_part": local_part,
     }
 
     resp = Aliases().create_new_alias(payload)
-    click.echo(f"Create New Alias Info: \n {json.dumps(resp.json(), indent=4)}")
+    #click.echo(f"Create New Alias Info: \n {json.dumps(resp.json(), indent=4)}")
+    click.echo(f"{json.dumps(resp.json(), indent=4)}")
 
 
 @alias.command(name="update", short_help='Update alias "descprition" and "from_name"')


### PR DESCRIPTION
new: added local_parts for custom mail aliasing and removed all text output from `addy new` command except the json (for further processing with jq).
